### PR TITLE
feat(tanglepay-deeplink): TanglePay DeepLink under iota stardust

### DIFF
--- a/src/app/components/wallet-deeplink/wallet-deeplink.component.ts
+++ b/src/app/components/wallet-deeplink/wallet-deeplink.component.ts
@@ -161,10 +161,7 @@ export class WalletDeeplinkComponent {
         'tanglepay://send/' +
           this.targetAddress +
           '?value=' +
-          +(Number(this.targetAmount) / NETWORK_DETAIL[this.network || DEFAULT_NETWORK].divideBy)
-            .toFixed(6)
-            .replace(/,/g, '.') +
-          '&unit=Mi' +
+          Number(this.targetAmount).toFixed(0) +
           '&tag=' +
           WEN_NAME.toLowerCase(),
       );


### PR DESCRIPTION
Hi, After tanglepay version 1.5.9, the deepLink’s unit parameter for iota transaction does not support Ki, Mi, Gi, Ti, Pi, etc., there is no need to pass this parameter, and we process it as MICRO by default.