### PR TITLE
Implemented single nft bulk buy

### DIFF
--- a/src/app/@api/order.api.ts
+++ b/src/app/@api/order.api.ts
@@ -7,6 +7,7 @@ import {
   WEN_FUNC,
   Build5Request,
   NftPurchaseRequest,
+  NftPurchaseBulkRequest,
   OrderTokenRequest,
   AddressValidationRequest,
   NftBidRequest,
@@ -26,6 +27,10 @@ export class OrderApi extends BaseApi<Transaction> {
 
   public orderNft = (req: Build5Request<NftPurchaseRequest>): Observable<Transaction | undefined> =>
     this.request(WEN_FUNC.orderNft, req);
+
+  public orderNfts = (
+    req: Build5Request<NftPurchaseBulkRequest>,
+  ): Observable<Transaction | undefined> => this.request(WEN_FUNC.orderNftBulk, req);
 
   public orderToken = (
     req: Build5Request<OrderTokenRequest>,

--- a/src/app/@shell/ui/header/header.component.html
+++ b/src/app/@shell/ui/header/header.component.html
@@ -251,6 +251,7 @@
   [isOpen]="isCheckoutOpen"
   [nft]="currentCheckoutNft"
   [collection]="currentCheckoutCollection"
+  [nftQuantity]="nftQty ?? 1"
   (wenOnClose)="closeCheckout()"
 ></wen-nft-checkout>
 

--- a/src/app/components/nft/components/nft-checkout/nft-checkout.component.html
+++ b/src/app/components/nft/components/nft-checkout/nft-checkout.component.html
@@ -65,41 +65,270 @@
         </a>
 
         <div
+          class="flex items-center p-5 mt-6 rounded-xl bg-alerts-warning dark:bg-alerts-warning-dark text-foregrounds-primary dark:text-foregrounds-primary"
+          *ngIf="nftQuantity > 1"
+        >
+          <wen-icon-alert-octagon class="mr-2.5 lg:mr-3.5"></wen-icon-alert-octagon>
+          <div class="text-base font-bold">
+            <span
+              >You have selected to perform a bulk order of this NFT. Please review quantity
+              selected before finalizing and purchase.</span
+            >
+          </div>
+        </div>
+
+        <div
           class="px-5 py-3 mt-8 lg:mt-auto bg-backgrounds-secondary dark:bg-backgrounds-secondary-dark rounded-2xl w-max"
         >
-          <div
-            class="text-xs font-medium text-foregrounds-secondary dark:text-foregrounds-secondary-dark"
-            i18n
-          >
-            Total price
-          </div>
-          <div
-            class="flex items-center mt-2 text-lg"
-            *ngIf="discount() < 1 && currentStep === stepType.CONFIRM"
-          >
-            <div class="mr-2 font-bold line-through text-foregrounds-tertiary">
-              {{ targetPrice | formatToken : collection?.mintingData?.network : true | async }}
+          <!-- Display when nftQuantity is not over 1 (Regular Order) -->
+          <ng-container *ngIf="!nftQuantity || nftQuantity <= 1">
+            <div
+              class="text-xs font-medium text-foregrounds-secondary dark:text-foregrounds-secondary-dark"
+              i18n
+            >
+              Total price
             </div>
-            <div class="mr-2 font-bold truncate">
-              {{
-                calc(targetPrice, discount())
-                  | formatToken : collection?.mintingData?.network : true
-                  | async
-              }}
+
+            <div
+              class="flex items-center mt-2 text-lg"
+              *ngIf="discount() < 1 && currentStep === stepType.CONFIRM"
+            >
+              <div class="mr-2 font-bold line-through text-foregrounds-tertiary">
+                {{ targetPrice | formatToken : collection?.mintingData?.network : true | async }}
+              </div>
+              <div class="mr-2 font-bold truncate">
+                {{
+                  calc(targetPrice, discount())
+                    | formatToken : collection?.mintingData?.network : true
+                    | async
+                }}
+              </div>
             </div>
-          </div>
-          <div
-            class="flex items-center mt-2 text-lg"
-            *ngIf="discount() === 1 || currentStep !== stepType.CONFIRM"
+
+            <div
+              class="flex items-center mt-2 text-lg"
+              *ngIf="discount() === 1 || currentStep !== stepType.CONFIRM"
+            >
+              <div class="mr-2 font-bold truncate">
+                {{
+                  currentStep !== stepType.CONFIRM
+                    ? (targetAmount | formatToken : collection?.mintingData?.network : true | async)
+                    : (targetPrice | formatToken : collection?.mintingData?.network : true | async)
+                }}
+              </div>
+            </div>
+          </ng-container>
+
+          <!-- Display when nftQuantity is over 1 (Bulk Order) -->
+          <ng-container
+            *ngIf="
+              nftQuantity > 1 &&
+                ((currentStep === stepType.CONFIRM && targetPrice !== null) ||
+                  (currentStep !== stepType.CONFIRM && targetAmount !== null));
+              else elseBlock
+            "
           >
-            <div class="mr-2 font-bold truncate">
-              {{
-                currentStep !== stepType.CONFIRM
-                  ? (targetAmount | formatToken : collection?.mintingData?.network : true | async)
-                  : (targetPrice | formatToken : collection?.mintingData?.network : true | async)
-              }}
+            <div class="flex flex-row justify-between items-center mt-2">
+              <!-- Price Each -->
+              <div class="flex flex-col items-center mr-4">
+                <div
+                  class="text-xs font-medium text-foregrounds-secondary dark:text-foregrounds-secondary-dark"
+                  i18n
+                >
+                  Price each
+                </div>
+
+                <div
+                  class="flex items-center mt-2 text-lg"
+                  *ngIf="discount() < 1 && currentStep === stepType.CONFIRM"
+                >
+                  <div class="mr-2 font-bold line-through text-foregrounds-tertiary">
+                    {{
+                      targetPrice | formatToken : collection?.mintingData?.network : true | async
+                    }}
+                  </div>
+                  <div class="mr-2 font-bold truncate">
+                    {{
+                      calc(targetPrice, discount())
+                        | formatToken : collection?.mintingData?.network : true
+                        | async
+                    }}
+                  </div>
+                </div>
+
+                <div
+                  class="flex items-center mt-2 text-lg"
+                  *ngIf="discount() === 1 || currentStep !== stepType.CONFIRM"
+                >
+                  <div class="mr-2 font-bold truncate">
+                    {{
+                      currentStep !== stepType.CONFIRM
+                        ? (pricePerItem
+                          | formatToken : collection?.mintingData?.network : true
+                          | async)
+                        : (targetPrice
+                          | formatToken : collection?.mintingData?.network : true
+                          | async)
+                    }}
+                  </div>
+                </div>
+              </div>
+
+              <!-- Order Qty -->
+              <div class="flex flex-col items-center mr-4">
+                <div
+                  class="text-xs font-medium text-foregrounds-secondary dark:text-foregrounds-secondary-dark"
+                  i18n
+                >
+                  Order quantity
+                </div>
+                <div class="flex items-center mt-2 text-lg">
+                  <div class="mr-2 font-bold truncate">
+                    {{ nftQuantity }}
+                  </div>
+                </div>
+              </div>
+
+              <!-- Total Price -->
+              <div class="flex flex-col items-center">
+                <div
+                  class="text-xs font-medium text-foregrounds-secondary dark:text-foregrounds-secondary-dark"
+                  i18n
+                >
+                  Total price
+                </div>
+
+                <div
+                  class="flex items-center mt-2 text-lg"
+                  *ngIf="discount() < 1 && currentStep === stepType.CONFIRM && targetPrice !== null"
+                >
+                  <div class="mr-2 font-bold line-through text-foregrounds-tertiary">
+                    {{
+                      targetPrice * nftQuantity
+                        | formatToken : collection?.mintingData?.network : true
+                        | async
+                    }}
+                  </div>
+                  <div class="mr-2 font-bold truncate">
+                    {{
+                      calc(targetPrice, discount()) * nftQuantity
+                        | formatToken : collection?.mintingData?.network : true
+                        | async
+                    }}
+                  </div>
+                </div>
+
+                <div
+                  class="flex items-center mt-2 text-lg"
+                  *ngIf="
+                    (currentStep === stepType.CONFIRM && targetPrice !== null) ||
+                    (currentStep !== stepType.CONFIRM && targetAmount !== null)
+                  "
+                >
+                  <div class="mr-2 font-bold truncate">
+                    {{
+                      currentStep !== stepType.CONFIRM && targetAmount !== null
+                        ? (targetAmount
+                          | formatToken : collection?.mintingData?.network : true
+                          | async)
+                        : (targetPrice * nftQuantity
+                          | formatToken : collection?.mintingData?.network : true
+                          | async)
+                    }}
+                  </div>
+                </div>
+              </div>
             </div>
-          </div>
+          </ng-container>
+
+          <!-- Warning/Error Message Block -->
+          <ng-template #elseBlock>
+            <div
+              class="px-5 py-3 mt-8 lg:mt-auto bg-backgrounds-secondary dark:bg-backgrounds-secondary-dark rounded-2xl w-max"
+              *ngIf="nftQuantity !== 1"
+            >
+              <div
+                class="flex items-center p-5 mt-6 rounded-xl bg-alerts-warning dark:bg-alerts-warning-dark text-foregrounds-primary dark:text-foregrounds-primary"
+              >
+                <wen-icon-alert-octagon class="mr-2.5 lg:mr-3.5"></wen-icon-alert-octagon>
+                <div class="text-base font-bold">
+                  <span>Warning: Missing or Invalid Data</span>
+                </div>
+              </div>
+
+              <div class="flex flex-row justify-between items-center mt-2">
+                <div class="flex flex-col items-center mr-4">
+                  <div class="flex flex-col items-center mr-4">
+                    <div
+                      class="text-xs font-medium text-foregrounds-secondary dark:text-foregrounds-secondary-dark"
+                      i18n
+                    >
+                      Target Price
+                    </div>
+                    <div class="text-lg font-bold truncate">
+                      {{ targetPrice }}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="flex flex-col items-center mr-4">
+                  <div class="flex flex-col items-center mr-4">
+                    <div
+                      class="text-xs font-medium text-foregrounds-secondary dark:text-foregrounds-secondary-dark"
+                      i18n
+                    >
+                      Target Amount
+                    </div>
+                    <div class="text-lg font-bold truncate">
+                      {{ targetAmount }}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="flex flex-col items-center mr-4">
+                  <div class="flex flex-col items-center mr-4">
+                    <div
+                      class="text-xs font-medium text-foregrounds-secondary dark:text-foregrounds-secondary-dark"
+                      i18n
+                    >
+                      Quantity Selected
+                    </div>
+                    <div class="text-lg font-bold truncate">
+                      {{ nftQuantity }}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="flex flex-col items-center mr-4">
+                  <div class="flex flex-col items-center mr-4">
+                    <div
+                      class="text-xs font-medium text-foregrounds-secondary dark:text-foregrounds-secondary-dark"
+                      i18n
+                    >
+                      Discount
+                    </div>
+                    <div class="text-lg font-bold truncate">
+                      {{ discount() }}
+                    </div>
+                  </div>
+                </div>
+
+                <div class="flex flex-col items-center mr-4">
+                  <div class="flex flex-col items-center mr-4">
+                    <div
+                      class="text-xs font-medium text-foregrounds-secondary dark:text-foregrounds-secondary-dark"
+                      i18n
+                    >
+                      Purchase Workflow Step
+                    </div>
+                    <div class="text-lg font-bold truncate">
+                      {{ currentStep }}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </ng-template>
         </div>
       </div>
     </div>
@@ -287,6 +516,7 @@
         (click)="goToNft()"
         nzSize="large"
         class="w-full mb-6 lg:mb-0 lg:mt-1"
+        *ngIf="!nftQuantity || nftQuantity <= 1"
         i18n
       >
         Show my NFT

--- a/src/app/components/nft/components/nft-checkout/nft-checkout.component.ts
+++ b/src/app/components/nft/components/nft-checkout/nft-checkout.component.ts
@@ -34,6 +34,7 @@ import {
   Transaction,
   TransactionType,
   TRANSACTION_AUTO_EXPIRY_MS,
+  NftPurchaseRequest,
 } from '@build-5/interfaces';
 import dayjs from 'dayjs';
 import { BehaviorSubject, firstValueFrom, interval, Subscription, take } from 'rxjs';
@@ -64,6 +65,7 @@ export class NftCheckoutComponent implements OnInit, OnDestroy {
   @Input() currentStep = StepType.CONFIRM;
 
   @Input() set isOpen(value: boolean) {
+    // console.log('Is Open changed:', value);
     this._isOpen = value;
     this.checkoutService.modalOpen$.next(value);
   }
@@ -86,6 +88,7 @@ export class NftCheckoutComponent implements OnInit, OnDestroy {
 
       if (this.currentStep === StepType.CONFIRM) {
         this.targetPrice = this._nft.availablePrice || this._nft.price || 0;
+        // console.log('targetPrice set, _nft.availablePrice, _nft.price, targetPrice: ', this._nft.availablePrice,  this._nft.price, this.targetPrice);
       }
     }
   }
@@ -111,6 +114,8 @@ export class NftCheckoutComponent implements OnInit, OnDestroy {
   get collection(): Collection | null | undefined {
     return this._collection;
   }
+
+  @Input() nftQuantity = 1;
 
   @Output() wenOnClose = new EventEmitter<void>();
 
@@ -156,12 +161,14 @@ export class NftCheckoutComponent implements OnInit, OnDestroy {
   ) {}
 
   public ngOnInit(): void {
+    // console.log('[nft-checkout] loaded, qty passed in: ', this.nftQuantity);
     this.receivedTransactions = false;
     const listeningToTransaction: string[] = [];
     this.transaction$.pipe(untilDestroyed(this)).subscribe((val) => {
       if (val && val.type === TransactionType.ORDER) {
         this.targetAddress = val.payload.targetAddress;
         this.targetAmount = val.payload.amount;
+        // console.log('target amount set using val.payload.amount.  val: ', val);
         const expiresOn: dayjs.Dayjs = dayjs(val.payload.expiresOn!.toDate());
         if (expiresOn.isBefore(dayjs()) || val.payload?.void || val.payload?.reconciled) {
           // It's expired.
@@ -414,34 +421,69 @@ export class NftCheckoutComponent implements OnInit, OnDestroy {
     return this.purchasedNft || this.nft;
   }
 
+  get pricePerItem(): number {
+    return (this.targetAmount ?? 0) / (this.nftQuantity || 1);
+  }
+
   public async proceedWithOrder(): Promise<void> {
     if (!this.collection || !this.nft || !this.agreeTermsConditions) {
       return;
     }
 
-    const params: any = {
-      collection: this.collection.uid,
-    };
+    if (this.nftQuantity > 1) {
+      const nfts: NftPurchaseRequest[] = [];
 
-    if (this.collection.type === CollectionType.CLASSIC) {
-      params.nft = this.nft.uid;
+      for (let i = 0; i < this.nftQuantity; i++) {
+        const nftData: NftPurchaseRequest = {
+          collection: this.collection.uid,
+        };
+
+        nfts.push(nftData);
+      }
+
+      const bulkPurchaseRequest = {
+        orders: nfts,
+      };
+
+      await this.auth.sign(bulkPurchaseRequest, (sc, finish) => {
+        this.notification
+          .processRequest(this.orderApi.orderNfts(sc), $localize`Order created.`, finish)
+          .subscribe((val: any) => {
+            this.transSubscription?.unsubscribe();
+            setItem(StorageItem.CheckoutTransaction, val.uid);
+            this.transSubscription = this.orderApi
+              .listen(val.uid)
+              .subscribe(<any>this.transaction$);
+            this.pushToHistory(val, val.uid, dayjs(), $localize`Waiting for transaction...`);
+          });
+      });
+    } else {
+      const params: any = {
+        collection: this.collection.uid,
+      };
+
+      if (this.collection.type === CollectionType.CLASSIC) {
+        params.nft = this.nft.uid;
+      }
+
+      // If owner is set CollectionType is not relevant.
+      if (this.nft.owner) {
+        params.nft = this.nft.uid;
+      }
+
+      await this.auth.sign(params, (sc, finish) => {
+        this.notification
+          .processRequest(this.orderApi.orderNft(sc), $localize`Order created.`, finish)
+          .subscribe((val: any) => {
+            this.transSubscription?.unsubscribe();
+            setItem(StorageItem.CheckoutTransaction, val.uid);
+            this.transSubscription = this.orderApi
+              .listen(val.uid)
+              .subscribe(<any>this.transaction$);
+            this.pushToHistory(val, val.uid, dayjs(), $localize`Waiting for transaction...`);
+          });
+      });
     }
-
-    // If owner is set CollectionType is not relevant.
-    if (this.nft.owner) {
-      params.nft = this.nft.uid;
-    }
-
-    await this.auth.sign(params, (sc, finish) => {
-      this.notification
-        .processRequest(this.orderApi.orderNft(sc), $localize`Order created.`, finish)
-        .subscribe((val: any) => {
-          this.transSubscription?.unsubscribe();
-          setItem(StorageItem.CheckoutTransaction, val.uid);
-          this.transSubscription = this.orderApi.listen(val.uid).subscribe(<any>this.transaction$);
-          this.pushToHistory(val, val.uid, dayjs(), $localize`Waiting for transaction...`);
-        });
-    });
   }
 
   public getTitle(): any {

--- a/src/app/pages/award/pages/new/new.page.ts
+++ b/src/app/pages/award/pages/new/new.page.ts
@@ -17,6 +17,8 @@ import {
   TEST_AVAILABLE_MINTABLE_NETWORKS,
   Token,
   TokenStatus,
+  getDefDecimalIfNotSet,
+  Network,
 } from '@build-5/interfaces';
 import { BehaviorSubject, of, Subscription, switchMap } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
@@ -27,7 +29,7 @@ import { NotificationService } from './../../../../@core/services/notification/n
 import { AuthService } from './../../../../components/auth/services/auth.service';
 
 import { FileApi } from '@api/file.api';
-import { getDefDecimalIfNotSet, Network } from '@build-5/interfaces';
+
 import { NzNotificationService } from 'ng-zorro-antd/notification';
 import { NzUploadChangeParam, NzUploadFile, NzUploadXHRArgs } from 'ng-zorro-antd/upload';
 

--- a/src/app/pages/nft/pages/nft/nft.page.html
+++ b/src/app/pages/nft/pages/nft/nft.page.html
@@ -248,28 +248,70 @@
         ></wen-connect-wallet>
       </div>
 
-      <div
-        *ngIf="!helper.isLocked(data.nft$ | async, data.collection$ | async, true) && helper.isAvailableForSale(data.nft$ | async, data.collection$ | async) && (!(data.nft$ | async)?.owner || (data.nft$ | async)?.owner !== (auth.member$ | async)?.uid)"
-        class="mt-10"
-      >
-        <button
-          nz-button
-          nzType="primary"
-          (click)="buy($event)"
-          *ngIf="auth.isLoggedIn$ | async"
-          nzBlock
-          nzSize="large"
-          i18n
-        >
-          Buy now
-        </button>
+      <ng-container *ngIf="(data.collection$ | async) as collection">
+        <ng-container *ngIf="(data.nft$ | async) as nft">
+          <div
+            *ngIf="!helper.isLocked(nft, collection, true) && helper.isAvailableForSale(nft, collection) && (!nft.owner || nft.owner !== (auth.member$ | async)?.uid)"
+            class="mt-10"
+          >
+            <!-- If Multiple Available Set Quantity -->
+            <div *ngIf="getAvailableNftQuantity(collection, nft) > 1">
+              <nz-form-item>
+                <nz-form-control
+                  i18n-nzErrorTip
+                  nzErrorTip="Minimum 1 and maximum {{ getAvailableNftQuantity(collection, nft) }}."
+                >
+                  <nz-input-group nzAddOnBefore="Set NFT Purchase Quantity:">
+                    <input
+                      nz-input
+                      type="number"
+                      [(ngModel)]="nftQtySelected"
+                      (ngModelChange)="updateQuantity()"
+                      #quantityInput="ngModel"
+                      min="1"
+                      max="{{ getAvailableNftQuantity(collection, nft) }}"
+                    />
+                  </nz-input-group>
+                </nz-form-control>
+              </nz-form-item>
+            </div>
 
-        <wen-connect-wallet
-          class="w-full"
-          wrapperClass="bg-backgrounds-tertiary dark:bg-backgrounds-tertiary-dark text-foregrounds-primary dark:text-foregrounds-primary-dark"
-          *ngIf="(auth.isLoggedIn$ | async) === false"
-        ></wen-connect-wallet>
-      </div>
+            <!-- Buy Now Button -->
+            <button
+              nz-button
+              nzType="primary"
+              (click)="buy($event)"
+              *ngIf="auth.isLoggedIn$ | async"
+              nzBlock
+              nzSize="large"
+              i18n
+            >
+              Buy now
+            </button>
+
+            <!-- Add to Cart Button
+            <button
+              nz-button
+              nzType="primary"
+              (click)="addToCart(nft)"
+              nzBlock
+              nzSize="large"
+              i18n
+              style="margin-top: 5px; margin-bottom: 5px"
+            >
+              Add to Cart
+            </button>
+            -->
+
+            <!-- Connect Wallet Component -->
+            <wen-connect-wallet
+              class="w-full"
+              wrapperClass="bg-backgrounds-tertiary dark:bg-backgrounds-tertiary-dark text-foregrounds-primary dark:text-foregrounds-primary-dark"
+              *ngIf="(auth.isLoggedIn$ | async) === false"
+            ></wen-connect-wallet>
+          </div>
+        </ng-container>
+      </ng-container>
 
       <div class="mt-12 font-medium" [innerHtml]="(data.nft$ | async)?.description| markdown"></div>
 
@@ -775,6 +817,7 @@
   [isOpen]="isCheckoutOpen"
   [nft]="data.nft$ | async"
   [collection]="data.collection$ | async"
+  [nftQuantity]="nftQtySelected"
   (wenOnClose)="isCheckoutOpen = false"
 ></wen-nft-checkout>
 <wen-nft-sale

--- a/src/app/pages/nft/services/helper.service.ts
+++ b/src/app/pages/nft/services/helper.service.ts
@@ -179,6 +179,18 @@ export class HelperService {
     );
   }
 
+  public getAvailNftQty(nft?: Nft | null, col?: Collection | null): number {
+    const isAvailableForSale = this.isAvailableForSale(nft, col);
+
+    if (nft?.placeholderNft && isAvailableForSale) {
+      return col?.availableNfts || 0;
+    } else if (isAvailableForSale) {
+      return 1;
+    }
+
+    return 0;
+  }
+
   public canBeSetForSale(nft?: Nft | null): boolean {
     if (nft?.auctionFrom || nft?.availableFrom) {
       return false;


### PR DESCRIPTION
On the NFT page, when applicable, an input will allow a quantity to be typed in or incremented/decremented using up/down arrows.  When "Buy now" button is pressed the input quantity of NFTs is passed to the checkout drawer.  

If a quantity of more than 1 is passed then it will display a warning informing the user that multiple NFTs have been selected to be purchased.

NFT purchase flow for user will be same as for single NFT buy but once purchased they will only have a button to close the checkout.

Once shopping cart is implemented the selected quantity can be passed to cart as well, initially setting quantity of that cart NFT item to that quantity.