### PR TITLE
Shopping cart bug fixes 1

### DIFF
--- a/src/app/components/cart/components/cart-modal/cart-modal.component.html
+++ b/src/app/components/cart/components/cart-modal/cart-modal.component.html
@@ -383,11 +383,6 @@
           </ng-template>
         </div>
         <ng-template #emptyCart>Your cart is empty.</ng-template>
-        <div class="tester">
-          Pending Transaction: {{ cartService.pendingTransaction$ | async }}
-          <br />
-          Transaction Expired: {{ helper.isExpired(cartService.pendingTransaction$ | async) }}
-        </div>
       </ng-container>
 
       <div class="text-center" *nzModalFooter>

--- a/src/app/components/cart/components/checkout/checkout-overlay.component.ts
+++ b/src/app/components/cart/components/checkout/checkout-overlay.component.ts
@@ -185,6 +185,7 @@ export class CheckoutOverlayComponent implements OnInit, OnDestroy {
           (<any>val).payload?.chainReference,
         );
 
+        this.removePurchasedGroupItems();
         this.currentStep = StepType.COMPLETE;
         this.updateStep(this.currentStep);
         this.cd.markForCheck();
@@ -493,7 +494,8 @@ export class CheckoutOverlayComponent implements OnInit, OnDestroy {
   private removePurchasedGroupItems(): void {
     if (this.selectedNetwork) {
       this.cartService.removeGroupItemsFromCart(this.selectedNetwork);
-      this.cartService.clearNetworkSelection();
+    } else {
+      this.cartService.removeGroupItemsFromCart();
     }
   }
 

--- a/src/app/components/cart/services/cart.service.ts
+++ b/src/app/components/cart/services/cart.service.ts
@@ -182,8 +182,7 @@ export class CartService {
               this.triggerChangeDetectionSubject$.next();
               clearInterval(this.transactionCheckInterval);
               this.transactionCheckInterval = null;
-            }
-            else if (transaction.payload?.void && !transaction.payload?.reconciled) {
+            } else if (transaction.payload?.void && !transaction.payload?.reconciled) {
               this.notification.error($localize`NFT purchase transaction expired.`, '');
               this.setCurrentStep(StepType.CONFIRM);
               removeItem(StorageItem.CheckoutTransaction);
@@ -191,8 +190,7 @@ export class CartService {
               this.triggerChangeDetectionSubject$.next();
               clearInterval(this.transactionCheckInterval);
               this.transactionCheckInterval = null;
-            }
-            else {
+            } else {
               removeItem(StorageItem.CheckoutTransaction);
               this.pendingTransaction$.next(undefined);
               this.triggerChangeDetectionSubject$.next();
@@ -725,7 +723,6 @@ export class CartService {
 
   private performCartUpdate(tokenSymbol: string): void {
     const updatedCartItems = this.cartItemsSubject$.value.filter((item) => {
-
       const itemTokenSymbol =
         (item.nft?.placeholderNft
           ? item.collection?.mintingData?.network

--- a/src/app/components/nft/components/nft-checkout/nft-checkout.component.html
+++ b/src/app/components/nft/components/nft-checkout/nft-checkout.component.html
@@ -556,9 +556,7 @@
     >
     </wen-send-funds>
 
-    <div>
-      network print: {{ collection?.mintingData?.network }}
-    </div>
+    <div>network print: {{ collection?.mintingData?.network }}</div>
     <wen-wallet-deeplink
       *ngIf="!helper.isExpired(transaction$ | async)"
       class="mt-6"

--- a/src/app/components/nft/components/nft-checkout/nft-checkout.component.html
+++ b/src/app/components/nft/components/nft-checkout/nft-checkout.component.html
@@ -556,6 +556,9 @@
     >
     </wen-send-funds>
 
+    <div>
+      network print: {{ collection?.mintingData?.network }}
+    </div>
     <wen-wallet-deeplink
       *ngIf="!helper.isExpired(transaction$ | async)"
       class="mt-6"


### PR DESCRIPTION
In this PR I've added the following:
- When cart checkout modal is closed and purchase transaction is successful then send notification that purchase transaction was successful, set step to CONFIRM and remove bought NFTs from cart.
- General bug fixes with managing pending transaction state while cart checkout modal is closed.

Pushing this to also test on production environment due to not being able to replicate another reported bug by @emmap3-do :

Bloom deep link not present on bulk or single NFT checkout component.

Normally when the Bloom deep link isn't present it is due to requiring a valid network (where Firefly and TanglePay deep links don't require this).  In debug, tested collection NFTs did show correct network and Bloom deep link was present.  Will perform test for reported production collection to see if I replicate the issue.